### PR TITLE
Make field configs available to content elements as config attribute

### DIFF
--- a/concerto-field.html
+++ b/concerto-field.html
@@ -8,7 +8,7 @@ fetching and displaying content elements.
 @element concerto-field
 @status alpha
 -->
-<polymer-element name="concerto-field" attributes="screenId fieldId fieldName baseURL contentStyle">
+<polymer-element name="concerto-field" attributes="screenId fieldId fieldName baseURL contentStyle optConfig">
   <template>
     <style>
       :host {
@@ -108,6 +108,14 @@ fetching and displaying content elements.
        * @attribute transition
        * @type core-transition
        * @default core-transition-fade
+       */
+
+      /**
+       * Optional field config
+       *
+       * @attribute optConfig
+       * @type Object
+       * @default {}
        */
 
       created: function (){
@@ -233,6 +241,7 @@ fetching and displaying content elements.
           title: contentData.name,
           contentId: contentData.id,
           duration: contentData.duration,
+          config: this.optConfig
         };
 
         // Flatten render_details

--- a/concerto-screen.html
+++ b/concerto-screen.html
@@ -47,7 +47,8 @@ The `concerto-screen` element provides the main Concerto screen.
               fieldId="{{position.field.id}}"
               fieldName="{{position.field.name}}"
               baseURL="{{baseURL}}"
-              contentStyle="{{position.style}}">
+              contentStyle="{{position.style}}"
+              optConfig="{{position.field.config}}">
             </concerto-field>
           </div>
         </template>

--- a/contents/concerto-client-time.html
+++ b/contents/concerto-client-time.html
@@ -5,7 +5,7 @@ The 'concerto-client-time' element provides the current client side time
 
 @element concerto-client-time
 -->
-<polymer-element name="concerto-client-time" attributes="path" constructor="ConcertoClientTime" extends="concerto-content">
+<polymer-element name="concerto-client-time" attributes="config" constructor="ConcertoClientTime" extends="concerto-content">
   <template>
     <style>
       #clientTime * {

--- a/contents/concerto-content.html
+++ b/contents/concerto-content.html
@@ -105,7 +105,11 @@ building specific Concerto content elements.
       fromJSON: function(data) {
         Object.keys(data).forEach(function(key) {
           if (key in this) {
-            this.setAttribute(key, data[key]);
+            if (typeof data[key] == 'object') {
+              this.setAttribute(key, JSON.stringify(data[key]));
+            } else {
+              this.setAttribute(key, data[key]);
+            }
           }
         }.bind(this));
         if (this.autoLoad) {

--- a/contents/concerto-ticker.html
+++ b/contents/concerto-ticker.html
@@ -9,7 +9,7 @@ production Ticker implementation.
 @element concerto-content
 @status alpha
 -->
-<polymer-element name="concerto-ticker" attributes="data" constructor="ConcertoTicker" extends="concerto-content">
+<polymer-element name="concerto-ticker" attributes="data config" constructor="ConcertoTicker" extends="concerto-content">
   <template>
     <style>
       #ticker * {

--- a/test/testdata/frontend/1/setup.json
+++ b/test/testdata/frontend/1/setup.json
@@ -19,7 +19,7 @@
           "id":1,
           "name":"Graphics",
           "config":{
-
+    
           }
         }
       },


### PR DESCRIPTION
Any element inheriting from the base content element should be able to access the 'config' attribute for field config details.